### PR TITLE
Closes #22 Configuro AUTH_USER_MODEL

### DIFF
--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -40,15 +40,15 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          cd api
+          cd backend
           pip install -r requirements/development.txt
       - name: Run pre-commit
         run: |
-          cd api
+          cd backend
           pre-commit run --all-files
       - name: Test with django
         env:
           DJANGO_SETTINGS_MODULE: ticket_manager.settings.testing
         run: |
-          cd api/ticket_manager
+          cd backend/ticket_manager
           pytest

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ### Instalación
 - Activar venv
 ```bash
-cd api
+cd backend
 pip install -r requirements/development.txt
 pre-commit install
 docker-compose up -d # Corre la db en modo daemon
@@ -15,7 +15,7 @@ docker-compose up -d # Corre la db en modo daemon
 ### Testing
 #### Correr los tests
 ```bash
-cd api/ticket_manager
+cd backend/ticket_manager
 pytest
 ```
 

--- a/backend/ticket_manager/ticket_manager/settings/base.py
+++ b/backend/ticket_manager/ticket_manager/settings/base.py
@@ -107,3 +107,4 @@ STATIC_URL = "static/"
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+AUTH_USER_MODEL = "users.User"

--- a/backend/ticket_manager/tickets/tests.py
+++ b/backend/ticket_manager/tickets/tests.py
@@ -1,3 +1,2 @@
-from django.test import TestCase
-
-# Create your tests here.
+def test_placeholder():
+    """test para evitar que rompa CI"""


### PR DESCRIPTION
- Se agregó un modelo custom de user pero hay que configurarlo para que django lo reconozca y sea sencillo empezar la app con ese modelo. Para eso se configura AUTH_USER_MODEL.

- Además, muevo la carpeta de workflows al root para que se corran los checks con github actions.
  - En ese sentido, agregué un test_placeholder para que encuentre al menos un test y no falle el CI (devuelve exit code 5).